### PR TITLE
Optimized and updated install, now using latest pngout

### DIFF
--- a/README
+++ b/README
@@ -8,6 +8,7 @@ The installation script installs also the following programs.
 - OptiPNG by Cosmin Truta (http://optipng.sourceforge.net)
 - pngout by Ken Silverman (http://advsys.net/ken/utils.htm)
 - advpng by Andrea Mazzoleni (http://advancemame.sourceforge.net/comp-readme.html)
+- pngnq by Stuart Coyle (http://pngnq.sourceforge.net/)
 
 === USAGE ===
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 ##
 # Author: Alex Kulikov <alex.kulikov@xing.com>
-# Rewritten by: Koen Punt <me@koen.pt>
+# Rewritten by:// Koen Punt <me@koen.pt>
 # Version: 0.3
 # Description: Installer for TinyPNG.
 ##
@@ -43,8 +43,8 @@ function installUtils ()
 {
   echo "Installing utilities..."
   $USE_SUDO$PKG_MANAGER update 2>&1 > /dev/null
-  $USE_SUDO$PKG_MANAGER install pngcrush advancecomp optipng 2>&1 > /dev/null
-  echo "Installed pngcrush, advancecomp and optipng"
+  $USE_SUDO$PKG_MANAGER install pngnq pngcrush advancecomp optipng 2>&1 > /dev/null
+  echo "Installed pngnq, pngcrush, advancecomp and optipng"
 }
 
 function detectArchitecture ()

--- a/tinypng
+++ b/tinypng
@@ -71,10 +71,8 @@ function crushdir() {
 
     crunshPNG $x
 
-    let end=`ls -l pngout.png | tr -s " " | cut -d " " -f 5`
+    let end=`ls -l $x | tr -s " " | cut -d " " -f 5`
     totalend=$(($totalend+$end))
-    rm $x
-    mv pngout.png $x
     sum=$(($start-$end))
     percent=$(($sum*100/$start))
     wrongsize=$(($sum<0))
@@ -100,9 +98,7 @@ function crushfile() {
   echo "tinypng: Crush file"
   let start=`ls -l $TARGET | tr -s " " | cut -d " " -f 5`
   crunshPNG $TARGET
-  let end=`ls -l pngout.png | tr -s " " | cut -d " " -f 5`
-  rm $TARGET
-  mv pngout.png $TARGET
+  let end=`ls -l $TARGET | tr -s " " | cut -d " " -f 5`
   sum=$(($start-$end))
   percent=$(($sum*100/$start))
   echo $TARGET "Saved:" $sum "Bytes ("$percent "%)"
@@ -111,27 +107,36 @@ function crushfile() {
 }
 
 function crunshPNG() {
-  pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB -brute -l 9 -max -reduce -m 0 -q $1
-  optipng -o7 -q pngout.png
-  pngout pngout.png -q -y -k0 -s0
-  advpng -z -4 pngout.png > /dev/null
+  EXTLESS=`echo $1 | sed -e 's/\.png$//'`
+  pngnq -n 256 -e '-pngnq.png' -d .tinypngtmp $1
+  pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB -brute -l 9 -max -reduce -m 0 -q .tinypngtmp/$EXTLESS-pngnq.png .tinypngtmp/$EXTLESS-pngcrush.png
+  optipng -o7 -q -out .tinypngtmp/$EXTLESS-optipng.png .tinypngtmp/$EXTLESS-pngcrush.png
+  pngout -q -y -k0 -s0 .tinypngtmp/$EXTLESS-optipng.png .tinypngtmp/$EXTLESS-pngout.png
+  advpng -z -4 .tinypngtmp/$EXTLESS-pngout.png > /dev/null
+  mv .tinypngtmp/$EXTLESS-pngout.png $1
 }
 
+function cleanup() {
+  rm -rf .tinypngtmp
+}
 
 # Is target a file or a directory
 function conditions() {
+  mkdir -p .tinypngtmp
   if [ -d "$TARGET" ]
   then
     copy
     count
     crushdir
     backup
+    cleanup
   fi
   if [ -f "$TARGET" ]
   then
     copy
     crushfile
     backup
+    cleanup
   fi
 }
 


### PR DESCRIPTION
Quite a lot of changes:
### In install.sh
- Updated to use latest PNGOUT (which has support for x86_64). 
- When on linux auto detect architecture, if that fails, fallback to selecting
- Added [Homebrew](http://mxcl.github.com/homebrew/) as supported package manager
### In tinypng
- When the source is a directory, ignore resource forks (`._*`)
- Suppressed `tar` warning of `Stripping '/'...` 
- Added `pngnq` (http://pngnq.sourceforge.net/), which does quantization on the image (combines similar colors).
