### PR TITLE
pngcrush: malformed or missing argument

### DIFF
--- a/tinypng
+++ b/tinypng
@@ -111,7 +111,7 @@ function crunshPNG() {
   EXTLESS=`echo $1 | sed -e 's/\.png$//'`
   convert $1 -background Black -alpha Background $1
   pngnq -n 256 -e '-pngnq.png' -d .tinypngtmp $1
-  pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB -brute -l 9 -max -reduce -m 0 -q .tinypngtmp/$EXTLESS-pngnq.png .tinypngtmp/$EXTLESS-pngcrush.png
+  pngcrush -rem gAMA -rem cHRM -rem iCCP -rem sRGB -brute -l 9 -reduce -q .tinypngtmp/$EXTLESS-pngnq.png .tinypngtmp/$EXTLESS-pngcrush.png
   optipng -o7 -q -out .tinypngtmp/$EXTLESS-optipng.png .tinypngtmp/$EXTLESS-pngcrush.png
   pngout -q -y -k0 -s0 .tinypngtmp/$EXTLESS-optipng.png .tinypngtmp/$EXTLESS-pngout.png
   advpng -z -4 .tinypngtmp/$EXTLESS-pngout.png > /dev/null


### PR DESCRIPTION
In pngcrush 1.7.71 wrong parameters:

Error: pngcrush: malformed or missing argument
-max  needs a value

Error: Ignoring invalid method: 0
-p needs a value between 1 and 9
